### PR TITLE
Add back self-contained deployment

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -595,14 +595,14 @@ Target "DotnetPackage" (fun _ ->
         try
             DotnetPack (fun c ->
                 { c with
-                    Configuration = Debug;
+                    Configuration = Release
                     OutputPath = Some (nugetDir @@ "dotnetcore")
                 }) proj
         with _ ->
             printfn "pack failed, retrying..."
             DotnetPack (fun c ->
                 { c with
-                    Configuration = Debug;
+                    Configuration = Release
                     OutputPath = Some (nugetDir @@ "dotnetcore")
                 }) proj
     )
@@ -624,7 +624,7 @@ Target "DotnetPackage" (fun _ ->
                 DotnetPublish (fun c ->
                     { c with
                         Runtime = runtime
-                        Framework = Some "netcoreapp1.0"
+                        Configuration = Release
                         OutputPath = Some (nugetDir @@ "dotnetcore" @@ projName @@ runtimeName)
                     }) proj
                 runtimeWorked <- true

--- a/src/app/Fake.netcore/Fake.netcore.fsproj
+++ b/src/app/Fake.netcore/Fake.netcore.fsproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Fake.netcore</AssemblyName>
     <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>


### PR DESCRIPTION
Sadly this yields
```
error FS0193 : internal error : The type initializer for '<StartupCode$FSharp-Compiler>.$Reshapedmsbuild' threw an exception. [C:\PROJ\FAKE\src\app\Fake.Core.Context\Fake.Core.Context.fsproj]
C:\Users\dragon\.nuget\packages\fsharp.net.sdk\1.0.0-alpha-000007\build\netstandard1.0\FSharp.NET.Core.Sdk.targets(141,9): error MSB3073: The command "dotnet exec --depsfile C:\Users\dragon\.nuget\packages\.tools/dotnet-compile-fsc/1.0.0-preview2-020000/netcoreapp1.0/dotnet-compile-fsc.deps.json --additionalprobingpath C:\Users\dragon\.nuget\packages C:\Users\dragon\.nuget\packages\dotnet-compile-fsc/1.0.0-preview2-020000/lib/netcoreapp1.0/dotnet-compile-fsc.dll @C:\PROJ\FAKE\src\app\Fake.Core.Context\obj\Release\netstandard1.6\netstandard1.6\dotnet-compile.rsp" exited with code 1. [C:\PROJ\FAKE\src\app\Fake.Core.Context\Fake.Core.Context.fsproj]
```

However this step is already ignored (because it failed since .fsproj upgrade)